### PR TITLE
Bug fix legacyExplorer models / methods

### DIFF
--- a/server/config.json
+++ b/server/config.json
@@ -1,6 +1,7 @@
 {
   "restApiRoot": "/api",
   "host": "0.0.0.0",
+  "legacyExplorer": false,
   "port": 3000,
   "remoting": {
     "context": {


### PR DESCRIPTION
Setting legacyExplorer=false prevents this error;

loopback deprecated Routes "/methods" and "/models" are considered dangerous and should not be used.
Disable them by setting "legacyExplorer=false" in "server/config.json" or via "app.set()".