### PR TITLE
Fix git clone target URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Please see LoopBack [Getting started part II](http://docs.strongloop.com/display/LB/Getting+started+part+II) for the tutorial that walks you through creating this application.
 
 ```
-$ git clone git@github.com:strongloop/loopback-getting-started-intermediate.git
+$ git clone https://github.com/strongloop/loopback-getting-started-intermediate.git
 $ cd loopback-getting-started-intermediate
 $ npm install
 $ node .


### PR DESCRIPTION
The git clone command shown will error-out due to incorrect target URL parameter.